### PR TITLE
SystemUI: add themes dynamic tiles icon

### DIFF
--- a/packages/SystemUI/res/drawable/ic_dynamic_qs_themes.xml
+++ b/packages/SystemUI/res/drawable/ic_dynamic_qs_themes.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (c) 2016 The CyanogenMod Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M21,5V3h-2v6c0,0.6-0.4,1-1,1s-1-0.4-1-1V3h-2v10c0,0.6-0.4,1-1,1s-1-0.4-1-1V7c0-0.6-0.4-1-1-1s-1,0.4-1,1v4
+c0,0.6-0.4,1-1,1s-1-0.4-1-1V8c0-0.6-0.4-1-1-1S7,7.4,7,8v8c0,0.6-0.4,1-1,1s-1-0.4-1-1V3H3v2H2v4h1v10c0,1.1,0.9,2,2,2h14
+c1.1,0,2-0.9,2-2V9h1V5H21z" />
+</vector>

--- a/packages/SystemUI/res/values/cm_arrays.xml
+++ b/packages/SystemUI/res/values/cm_arrays.xml
@@ -62,6 +62,7 @@
         <item>@string/dynamic_qs_tile_su_label</item>
         <item>@string/dynamic_qs_tile_adb_label</item>
         <item>@string/dynamic_qs_tile_live_display_label</item>
+        <item>@string/dynamic_qs_tile_themes_label</item>
     </string-array>
     <string-array name="dynamic_qs_tiles_icons_resources_ids" translatable="false">
         <item>ic_dynamic_qs_next_alarm</item>
@@ -69,6 +70,7 @@
         <item>ic_dynamic_qs_su</item>
         <item>ic_dynamic_qs_adb</item>
         <item>ic_dynamic_qs_live_display</item>
+        <item>ic_dynamic_qs_themes</item>
     </string-array>
     <string-array name="dynamic_qs_tiles_values" translatable="false">
         <item>next_alarm</item>
@@ -76,6 +78,7 @@
         <item>su</item>
         <item>adb</item>
         <item>live_display</item>
+        <item>themes</item>
     </string-array>
 
     <array name="dockbatterymeter_bolt_points" translatable="false">

--- a/packages/SystemUI/res/values/cm_strings.xml
+++ b/packages/SystemUI/res/values/cm_strings.xml
@@ -214,6 +214,7 @@
     <string name="dynamic_qs_tile_su_label">Root access</string>
     <string name="dynamic_qs_tile_adb_label" translatable="false">ADB</string>
     <string name="dynamic_qs_tile_live_display_label" translatable="false">LiveDisplay</string>
+    <string name="dynamic_qs_tile_themes_label" translatable="false">Themes</string>
 
     <string name="quick_settings_title_advanced_location">Tri-state location</string>
 

--- a/packages/SystemUI/src/com/android/systemui/qs/QSDragPanel.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/QSDragPanel.java
@@ -2080,6 +2080,7 @@ public class QSDragPanel extends QSPanel implements View.OnDragListener, View.On
                 if (split != null && split.length > 2) {
                     return split[1];
                 }
+                return spec;
             }
             return null;
         }
@@ -2094,15 +2095,15 @@ public class QSDragPanel extends QSPanel implements View.OnDragListener, View.On
                     /** for {@link cyanogenmod.app.StatusBarPanelCustomTile#persistableKey()} **/
                     return split[2];
                 }
+                return spec;
             }
             return null;
         }
 
         private Drawable getQSTileIcon(String spec) {
-            if (QSUtils.isDynamicQsTile(spec)) {
-                return QSTile.ResourceIcon.get(
-                        QSUtils.getDynamicQSTileResIconId(mContext, UserHandle.myUserId(), spec))
-                        .getDrawable(mContext);
+            if (QSUtils.isDynamicQsTile(extractTileTagFromSpec(spec))) {
+                return QSTile.ResourceIcon.get(QSUtils.getDynamicQSTileResIconId(mContext,
+                        UserHandle.myUserId(), extractTileTagFromSpec(spec))).getDrawable(mContext);
             } else if (QSUtils.isStaticQsTile(spec)) {
                 final int res = QSTileHost.getIconResource(spec);
                 if (res != 0) {


### PR DESCRIPTION
Resolves the themes tile having the default android activity icon. Also
resolves other dynamic tiles not being queried properly.

Ticket: OSS NIGHTLIES-2967

Change-Id: I532eeaef417195f3148915b777e7ab175b1089aa
Signed-off-by: Roman Birg <roman@cyngn.com>