### PR TITLE
Fix google-explicit-constructor warnings in frameworks/base

### DIFF
--- a/libs/hwui/AnimationContext.h
+++ b/libs/hwui/AnimationContext.h
@@ -57,7 +57,7 @@ public:
 
 private:
     friend class AnimationContext;
-    AnimationHandle(AnimationContext& context);
+    explicit AnimationHandle(AnimationContext& context);
     AnimationHandle(RenderNode& animatingNode, AnimationContext& context);
     ~AnimationHandle();
 
@@ -75,7 +75,7 @@ private:
 class AnimationContext {
     PREVENT_COPY_AND_ASSIGN(AnimationContext);
 public:
-    ANDROID_API AnimationContext(renderthread::TimeLord& clock);
+    ANDROID_API explicit AnimationContext(renderthread::TimeLord& clock);
     ANDROID_API virtual ~AnimationContext();
 
     nsecs_t frameTimeMs() { return mFrameTimeMs; }

--- a/libs/hwui/AnimatorManager.h
+++ b/libs/hwui/AnimatorManager.h
@@ -35,7 +35,7 @@ class TreeInfo;
 class AnimatorManager {
     PREVENT_COPY_AND_ASSIGN(AnimatorManager);
 public:
-    AnimatorManager(RenderNode& parent);
+    explicit AnimatorManager(RenderNode& parent);
     ~AnimatorManager();
 
     void addAnimator(const sp<BaseRenderNodeAnimator>& animator);

--- a/libs/hwui/Caches.h
+++ b/libs/hwui/Caches.h
@@ -83,7 +83,7 @@ public:
         return sInstance != nullptr;
     }
 private:
-    Caches(RenderState& renderState);
+    explicit Caches(RenderState& renderState);
     static Caches* sInstance;
 
 public:

--- a/libs/hwui/CanvasProperty.h
+++ b/libs/hwui/CanvasProperty.h
@@ -28,7 +28,7 @@ namespace uirenderer {
 class CanvasPropertyPrimitive : public VirtualLightRefBase {
     PREVENT_COPY_AND_ASSIGN(CanvasPropertyPrimitive);
 public:
-    CanvasPropertyPrimitive(float initialValue) : value(initialValue) {}
+    explicit CanvasPropertyPrimitive(float initialValue) : value(initialValue) {}
 
     float value;
 };
@@ -36,7 +36,7 @@ public:
 class CanvasPropertyPaint : public VirtualLightRefBase {
     PREVENT_COPY_AND_ASSIGN(CanvasPropertyPaint);
 public:
-    CanvasPropertyPaint(const SkPaint& initialValue) : value(initialValue) {}
+    explicit CanvasPropertyPaint(const SkPaint& initialValue) : value(initialValue) {}
 
     SkPaint value;
 };

--- a/libs/hwui/CanvasState.h
+++ b/libs/hwui/CanvasState.h
@@ -73,7 +73,7 @@ public:
 
 class ANDROID_API CanvasState {
 public:
-    CanvasState(CanvasStateClient& renderer);
+    explicit CanvasState(CanvasStateClient& renderer);
     ~CanvasState();
 
     /**

--- a/libs/hwui/DeferredDisplayList.h
+++ b/libs/hwui/DeferredDisplayList.h
@@ -82,7 +82,7 @@ public:
 class DeferredDisplayList {
     friend struct DeferStateStruct; // used to give access to allocator
 public:
-    DeferredDisplayList(const Rect& bounds, bool avoidOverdraw = true) :
+    explicit DeferredDisplayList(const Rect& bounds, bool avoidOverdraw = true) :
             mBounds(bounds), mAvoidOverdraw(avoidOverdraw) {
         clear();
     }

--- a/libs/hwui/Dither.h
+++ b/libs/hwui/Dither.h
@@ -37,7 +37,7 @@ class Program;
  */
 class Dither {
 public:
-    Dither(Caches& caches);
+    explicit Dither(Caches& caches);
 
     void clear();
     void setupProgram(Program& program, GLuint* textureUnit);

--- a/libs/hwui/FrameInfo.h
+++ b/libs/hwui/FrameInfo.h
@@ -65,7 +65,7 @@ namespace FrameInfoFlags {
 
 class ANDROID_API UiFrameInfoBuilder {
 public:
-    UiFrameInfoBuilder(int64_t* buffer) : mBuffer(buffer) {
+    explicit UiFrameInfoBuilder(int64_t* buffer) : mBuffer(buffer) {
         memset(mBuffer, 0, UI_THREAD_FRAME_INFO_SIZE * sizeof(int64_t));
     }
 

--- a/libs/hwui/FrameInfoVisualizer.h
+++ b/libs/hwui/FrameInfoVisualizer.h
@@ -39,7 +39,7 @@ typedef RingBuffer<FrameInfo, 120> FrameInfoSource;
 
 class FrameInfoVisualizer {
 public:
-    FrameInfoVisualizer(FrameInfoSource& source);
+    explicit FrameInfoVisualizer(FrameInfoSource& source);
     ~FrameInfoVisualizer();
 
     bool consumeProperties();

--- a/libs/hwui/GradientCache.h
+++ b/libs/hwui/GradientCache.h
@@ -104,7 +104,7 @@ inline hash_t hash_type(const GradientCacheEntry& entry) {
  */
 class GradientCache: public OnEntryRemoved<GradientCacheEntry, Texture*> {
 public:
-    GradientCache(Extensions& extensions);
+    explicit GradientCache(Extensions& extensions);
     ~GradientCache();
 
     /**

--- a/libs/hwui/JankTracker.h
+++ b/libs/hwui/JankTracker.h
@@ -54,7 +54,7 @@ struct ProfileData {
 // TODO: Replace DrawProfiler with this
 class JankTracker {
 public:
-    JankTracker(nsecs_t frameIntervalNanos);
+    explicit JankTracker(nsecs_t frameIntervalNanos);
     ~JankTracker();
 
     void addFrame(const FrameInfo& frame);

--- a/libs/hwui/LayerCache.h
+++ b/libs/hwui/LayerCache.h
@@ -104,7 +104,7 @@ private:
             mHeight = Layer::computeIdealHeight(layerHeight);
         }
 
-        LayerEntry(Layer* layer):
+        explicit LayerEntry(Layer* layer):
             mLayer(layer), mWidth(layer->getWidth()), mHeight(layer->getHeight()) {
         }
 

--- a/libs/hwui/Matrix.h
+++ b/libs/hwui/Matrix.h
@@ -81,11 +81,11 @@ public:
         loadIdentity();
     }
 
-    Matrix4(const float* v) {
+    explicit Matrix4(const float* v) {
         load(v);
     }
 
-    Matrix4(const SkMatrix& v) {
+    Matrix4(const SkMatrix& v) {  // NOLINT, implicit
         load(v);
     }
 

--- a/libs/hwui/OpenGLRenderer.h
+++ b/libs/hwui/OpenGLRenderer.h
@@ -114,7 +114,7 @@ enum ModelViewMode {
  */
 class OpenGLRenderer : public CanvasStateClient {
 public:
-    OpenGLRenderer(RenderState& renderState);
+    explicit OpenGLRenderer(RenderState& renderState);
     virtual ~OpenGLRenderer();
 
     /**

--- a/libs/hwui/PatchCache.h
+++ b/libs/hwui/PatchCache.h
@@ -51,7 +51,7 @@ class Caches;
 
 class PatchCache {
 public:
-    PatchCache(RenderState& renderState);
+    explicit PatchCache(RenderState& renderState);
     ~PatchCache();
     void init();
 

--- a/libs/hwui/PathCache.h
+++ b/libs/hwui/PathCache.h
@@ -290,7 +290,7 @@ private:
 
     class PathProcessor: public TaskProcessor<SkBitmap*> {
     public:
-        PathProcessor(Caches& caches);
+        explicit PathProcessor(Caches& caches);
         ~PathProcessor() { }
 
         virtual void onProcess(const sp<Task<SkBitmap*> >& task) override;

--- a/libs/hwui/ProgramCache.h
+++ b/libs/hwui/ProgramCache.h
@@ -40,7 +40,7 @@ namespace uirenderer {
  */
 class ProgramCache {
 public:
-    ProgramCache(Extensions& extensions);
+    explicit ProgramCache(Extensions& extensions);
     ~ProgramCache();
 
     Program* get(const ProgramDescription& description);

--- a/libs/hwui/Rect.h
+++ b/libs/hwui/Rect.h
@@ -72,7 +72,7 @@ public:
             bottom(height) {
     }
 
-    inline Rect(const SkRect& rect):
+    inline Rect(const SkRect& rect):  // NOLINT, implicit
             left(rect.fLeft),
             top(rect.fTop),
             right(rect.fRight),

--- a/libs/hwui/RenderBufferCache.h
+++ b/libs/hwui/RenderBufferCache.h
@@ -85,7 +85,7 @@ private:
             mBuffer(nullptr), mFormat(format), mWidth(width), mHeight(height) {
         }
 
-        RenderBufferEntry(RenderBuffer* buffer):
+        explicit RenderBufferEntry(RenderBuffer* buffer):
             mBuffer(buffer), mFormat(buffer->getFormat()),
             mWidth(buffer->getWidth()), mHeight(buffer->getHeight()) {
         }

--- a/libs/hwui/ResourceCache.h
+++ b/libs/hwui/ResourceCache.h
@@ -42,7 +42,7 @@ enum ResourceType {
 class ResourceReference {
 public:
 
-    ResourceReference(ResourceType type) {
+    explicit ResourceReference(ResourceType type) {
         refCount = 0; destroyed = false; resourceType = type;
     }
 

--- a/libs/hwui/SkiaCanvasProxy.h
+++ b/libs/hwui/SkiaCanvasProxy.h
@@ -39,7 +39,7 @@ namespace uirenderer {
  */
 class ANDROID_API SkiaCanvasProxy : public SkCanvas {
 public:
-    SkiaCanvasProxy(Canvas* canvas, bool filterHwuiCalls = false);
+    explicit SkiaCanvasProxy(Canvas* canvas, bool filterHwuiCalls = false);
     virtual ~SkiaCanvasProxy() {}
 
 protected:

--- a/libs/hwui/TextDropShadowCache.h
+++ b/libs/hwui/TextDropShadowCache.h
@@ -117,7 +117,7 @@ inline hash_t hash_type(const ShadowText& entry) {
  * Alpha texture used to represent a shadow.
  */
 struct ShadowTexture: public Texture {
-    ShadowTexture(Caches& caches): Texture(caches) {
+    explicit ShadowTexture(Caches& caches): Texture(caches) {
     }
 
     float left;
@@ -127,7 +127,7 @@ struct ShadowTexture: public Texture {
 class TextDropShadowCache: public OnEntryRemoved<ShadowText, ShadowTexture*> {
 public:
     TextDropShadowCache();
-    TextDropShadowCache(uint32_t maxByteSize);
+    explicit TextDropShadowCache(uint32_t maxByteSize);
     ~TextDropShadowCache();
 
     /**

--- a/libs/hwui/Texture.h
+++ b/libs/hwui/Texture.h
@@ -30,7 +30,7 @@ class UvMapper;
  */
 class Texture {
 public:
-    Texture(Caches& caches) : mCaches(caches) { }
+    explicit Texture(Caches& caches) : mCaches(caches) { }
 
     virtual ~Texture() { }
 
@@ -120,7 +120,7 @@ private:
 
 class AutoTexture {
 public:
-    AutoTexture(const Texture* texture): mTexture(texture) { }
+    explicit AutoTexture(const Texture* texture): mTexture(texture) { }
     ~AutoTexture() {
         if (mTexture && mTexture->cleanup) {
             mTexture->deleteTexture();

--- a/libs/hwui/renderthread/RenderTask.h
+++ b/libs/hwui/renderthread/RenderTask.h
@@ -73,7 +73,7 @@ typedef void* (*RunnableMethod)(void* data);
 
 class MethodInvokeRenderTask : public RenderTask {
 public:
-    MethodInvokeRenderTask(RunnableMethod method)
+    explicit MethodInvokeRenderTask(RunnableMethod method)
         : mMethod(method), mReturnPtr(nullptr) {}
 
     void* payload() { return mData; }

--- a/libs/hwui/thread/Barrier.h
+++ b/libs/hwui/thread/Barrier.h
@@ -24,7 +24,7 @@ namespace uirenderer {
 
 class Barrier {
 public:
-    Barrier(Condition::WakeUpType type = Condition::WAKE_UP_ALL) : mType(type), mOpened(false) { }
+    explicit Barrier(Condition::WakeUpType type = Condition::WAKE_UP_ALL) : mType(type), mOpened(false) { }
     ~Barrier() { }
 
     void open() {

--- a/libs/hwui/thread/Future.h
+++ b/libs/hwui/thread/Future.h
@@ -27,7 +27,7 @@ namespace uirenderer {
 template<typename T>
 class Future: public LightRefBase<Future<T> > {
 public:
-    Future(Condition::WakeUpType type = Condition::WAKE_UP_ONE): mBarrier(type), mResult() { }
+    explicit Future(Condition::WakeUpType type = Condition::WAKE_UP_ONE): mBarrier(type), mResult() { }
     ~Future() { }
 
     /**

--- a/libs/hwui/thread/Signal.h
+++ b/libs/hwui/thread/Signal.h
@@ -26,7 +26,7 @@ namespace uirenderer {
 
 class Signal {
 public:
-    Signal(Condition::WakeUpType type = Condition::WAKE_UP_ALL) : mType(type), mSignaled(false) { }
+    explicit Signal(Condition::WakeUpType type = Condition::WAKE_UP_ALL) : mType(type), mSignaled(false) { }
     ~Signal() { }
 
     void signal() {

--- a/libs/hwui/thread/TaskManager.h
+++ b/libs/hwui/thread/TaskManager.h
@@ -77,7 +77,7 @@ private:
 
     class WorkerThread: public Thread {
     public:
-        WorkerThread(const String8 name): mSignal(Condition::WAKE_UP_ONE), mName(name) { }
+        explicit WorkerThread(const String8 name): mSignal(Condition::WAKE_UP_ONE), mName(name) { }
 
         bool addTask(TaskWrapper task);
         size_t getTaskCount() const;

--- a/libs/hwui/thread/TaskProcessor.h
+++ b/libs/hwui/thread/TaskProcessor.h
@@ -36,7 +36,7 @@ public:
 template<typename T>
 class TaskProcessor: public TaskProcessorBase {
 public:
-    TaskProcessor(TaskManager* manager): mManager(manager) { }
+    explicit TaskProcessor(TaskManager* manager): mManager(manager) { }
     virtual ~TaskProcessor() { }
 
     void add(const sp<Task<T> >& task) {

--- a/libs/hwui/utils/SortedListImpl.h
+++ b/libs/hwui/utils/SortedListImpl.h
@@ -25,7 +25,7 @@ namespace uirenderer {
 class SortedListImpl: public VectorImpl {
 public:
     SortedListImpl(size_t itemSize, uint32_t flags);
-    SortedListImpl(const VectorImpl& rhs);
+    explicit SortedListImpl(const VectorImpl& rhs);
     virtual ~SortedListImpl();
 
     SortedListImpl& operator =(const SortedListImpl& rhs);


### PR DESCRIPTION
* Add explicit keyword to conversion constructors.
* Add NOLINT to implicit conversion constructors.

Bug: 28341362
Test: build with clang-tidy
Change-Id: Ie4d37072ab57d1662d18db4de1c8577247f43337