### PR TITLE
StorageManager: Improve exception handling

### DIFF
--- a/core/java/android/os/storage/StorageManager.java
+++ b/core/java/android/os/storage/StorageManager.java
@@ -50,6 +50,7 @@ import com.android.internal.util.Preconditions;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.lang.ref.WeakReference;
@@ -952,10 +953,17 @@ public class StorageManager {
         try (final FileInputStream fis = new FileInputStream(path);
                 final BufferedReader reader = new BufferedReader(new InputStreamReader(fis));) {
             return Long.parseLong(reader.readLine());
-        } catch (Exception e) {
-            Slog.w(TAG, "readLong(): could not read " + path + ": " + e);
+        } catch (FileNotFoundException e) {
+            // This is expected since we are trying to parse multiple paths.
+            Slog.i(TAG, "readLong(): Path doesn't exist: " + path + ": " + e);
             return 0;
-        }
+        } catch (NumberFormatException e) {
+            Slog.e(TAG, "readLong(): Could not parse " + path + ": " + e);
+            return 0;
+        } catch (Exception e) {
+            Slog.e(TAG, "readLong(): Unknown exception while opening " + path + ": " + e);
+            return 0;
+       }
     }
 
     /** @removed */


### PR DESCRIPTION
When "getPrimaryStorageSize" provides a path
to "readLong", the option that the path
doesn't exist is expected, since it tries
all paths from "INTERNAL_STORAGE_SIZE_PATHS"
until there is success.

This patch makes us catch the "FileNotFoundException"
and "NumberFormatException" seperately.

For the above reason a "FileNotFoundException"
is now treated as an information only.
The "NumberFormatException" and other exceptions
are now treated as error since those are not
expected to happen.

Change-Id: I5316f9c3108e36c31b27dc5df8bf8ac4d4257629
Signed-off-by: Alex Naidis <alex.naidis@linux.com>