### PR TITLE
Show infinity for large notification counts

### DIFF
--- a/packages/SettingsLib/res/values-it/cm_strings.xml
+++ b/packages/SettingsLib/res/values-it/cm_strings.xml
@@ -27,9 +27,5 @@
   <string name="picker_activities">Attività</string>
   <string name="select_custom_app_title">Seleziona app personalizzata</string>
   <string name="select_custom_activity_title">Seleziona attività personalizzata</string>
-<<<<<<< HEAD
-  <string name="lockscreen_targets_message">Scorciatoie schermata di blocco</string>
-=======
   <string name="lockscreen_targets_message">Scorciatoie blocco schermo</string>
->>>>>>> de17832... Automatic translation import
 </resources>

--- a/packages/SystemUI/res/values/cm_strings.xml
+++ b/packages/SystemUI/res/values/cm_strings.xml
@@ -108,4 +108,6 @@
 
     <!-- Path data for circle battery -->
     <string name="battery_circle_path" translatable="false">M 12 3.5 C 16.6944203736 3.5 20.5 7.30557962644 20.5 12 C 20.5 16.6944203736 16.6944203736 20.5 12 20.5 C 7.30557962644 20.5 3.5 16.6944203736 3.5 12 C 3.5 7.30557962644 7.30557962644 3.5 12 3.5 Z</string>
+
+    <string name="status_bar_notification_info_overflow" translatable="false">\u221E</string>
 </resources>

--- a/packages/SystemUI/src/com/android/systemui/statusbar/StatusBarIconView.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/StatusBarIconView.java
@@ -320,7 +320,7 @@ public class StatusBarIconView extends AnimatedImageView {
                 android.R.integer.status_bar_notification_info_maxnum);
         if (mIcon.number > tooBig) {
             str = getContext().getResources().getString(
-                        android.R.string.status_bar_notification_info_overflow);
+                        R.string.status_bar_notification_info_overflow);
         } else {
             NumberFormat f = NumberFormat.getIntegerInstance();
             str = f.format(mIcon.number);


### PR DESCRIPTION
This patch adds a new string to SystemUI for displaying the infinity
symbol when a notification has a count larger than 999.  This only
affects the notification icon in the status bar and does not change
the text displayed in the actual notification.

These changes were manually cherry-picked from cm-13.0.

Change-Id: I3481aac13cd90ee20ed48194df3ec789c16c8b4b